### PR TITLE
Add support for DESTDIR installation.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -126,12 +126,12 @@ rebuild_autogen() {
 	touch doc/agdoc.texi # build later
 	make CFLAGS=-Wno-error
 	make check
-	make install
+	make DESTDIR="${DESTDIR}" install
 	cd doc
 	PATH="$FINALPREFIX/bin:$PATH"
 	rm agdoc.texi
 	make
-	make install
+	make DESTDIR="${DESTDIR}" install
 	cd ../../..
 
 	echo "=== BOOTSTRAP COMPLETE ==="

--- a/bootstrap_tarball.sh
+++ b/bootstrap_tarball.sh
@@ -186,12 +186,12 @@ rebuild_autogen() {
 	touch doc/agdoc.texi # build later
 	make CFLAGS=-Wno-error
 	make check
-	make install
+	make DESTDIR="${DESTDIR}" install
 	cd doc
 	PATH="$FINALPREFIX/bin:$PATH"
 	rm agdoc.texi
 	make
-	make install
+	make DESTDIR="${DESTDIR}" install
 	cd ../../..
 
 	echo "=== BOOTSTRAP COMPLETE ==="


### PR DESCRIPTION
Neither changing PREFIX, not adjusting LIBDATADIR seem to work nicerly (latter breaks first stage `tpl-config.tlib` build).

I think in live-bootstrap I'll then run the whole thing, set `FINALPREFIX=/usr`. But then I need make install to support DESTDIR variable.

In addition to that, 1 test is failing in live-bootstrap, but maybe I'll just remove it using `sed` in live-bootstrap.