### PR TITLE
Fix missing return value in getGuileVersion

### DIFF
--- a/getGuileVersion.c
+++ b/getGuileVersion.c
@@ -15,4 +15,5 @@
 
 int main() {
 	printf("%u%02u%03u\n", SCM_MAJOR_VERSION, SCM_MINOR_VERSION, SCM_MICRO_VERSION);
+	return 0;
 }


### PR DESCRIPTION
Without this, the return code will be unpredictable, causing failures with "set -e" or ERR traps.